### PR TITLE
Implement text wordwrap

### DIFF
--- a/Builtin/LUIBlockText.py
+++ b/Builtin/LUIBlockText.py
@@ -1,0 +1,100 @@
+
+from panda3d.core import LVecBase2i
+from LUIObject import LUIObject
+from LUILabel import LUILabel
+from LUIInitialState import LUIInitialState
+
+__all__ = ["LUIBlockText"]
+
+
+class LUIBlockText(LUIObject):
+
+    """ Small helper class to format labels into paragraphs.
+    Uses LUILabels internally """
+
+    def __init__(self, **kwargs):
+        """ Creates a new block of text. """
+        LUIObject.__init__(self)
+        LUIInitialState.init(self, kwargs)
+        self._cursor = LVecBase2i(0)
+        self._last_size = 14
+
+        self.labels = []
+
+
+    def clear(self):
+        """ Removes all text from this label and resets it to the initial state.
+        This will also detach the sub-labels from this label. """
+        self._cursor.set(0, 0)
+        self.labels = []
+        self.remove_all_children()
+
+
+    def newline(self, font_size=None):
+        """ Moves the cursor to the next line. The font size controls how much
+        the cursor will move. By default, the font size of the last added text
+        is used, or if no text was added yet, a size of 14."""
+        self._cursor.x = 0
+        if font_size is None:
+            font_size = self._last_size
+        self._cursor.y += font_size + 2
+
+
+    def add(self, *args, **kwargs):
+        """ Appends a new text. The arguments are equal to the arguments of
+        LUILabel. The arguments shouldn't contain information about the
+        placement like top_left, or center_vertical, since the labels are
+        placed at explicit positions. """
+        self._last_size = kwargs.get("font_size", 14)
+        label = LUILabel(parent=self, left=self._cursor.x, top=self._cursor.y, width=self.get_width(),
+                         *args, **kwargs)
+
+        self.labels.append(label)
+
+        # This is a bit of a hack, we should use a horizontal layout, but we
+        # don't for performance reasons.
+        self._cursor.y += label.text_handle.height
+
+        # After every paragraph, we add a new line.
+        self.newline()
+
+
+    def set_text(self, text):
+        """ Replaces the text with new text """
+        self.clear()
+        self.add(text=text)
+
+
+    def update_height(self):
+        """ Updates the height of the element, adding a newline to the end of
+        every paragraph """
+        top = 0
+        for child in self.labels:
+            child.top = top
+            top += child._text.height
+         
+            # Newline
+            top += self._last_size + 2
+
+
+    def set_wrap(self, wrap):
+        """ Sets text wrapping for the element.  Wrapping breaks lines on
+        spaces, and breaks words if the word is longer than the line 
+        length. """
+        for child in self.children:
+            for c in child.children:
+                c.set_wordwrap(wrap)
+
+        self.update_height()
+
+
+    def set_width(self, width):
+        """ Sets the width of this element, and turns on wrapping. """
+        for child in self.children:
+            child.set_width(width)
+            
+            # Need to force an update to the text when the width changes.
+            for c in child.children:
+                c.set_wordwrap(True)
+
+        self.update_height()   

--- a/Builtin/LUILabel.py
+++ b/Builtin/LUILabel.py
@@ -13,11 +13,20 @@ class LUILabel(LUIObject):
     DEFAULT_COLOR = (0.9, 0.9, 0.9, 1)
     DEFAULT_USE_SHADOW = True
 
-    def __init__(self, text=u"Label", shadow=None, font_size=14, font="label", color=None, **kwargs):
+    def __init__(self, text=u"Label", shadow=None, font_size=14, font="label", color=None, wordwrap=False, **kwargs):
         """ Creates a new label. If shadow is True, a small text shadow will be
         rendered below the actual text. """
         LUIObject.__init__(self)
-        self._text = LUIText(self, unicode(text), font, font_size)
+        LUIInitialState.init(self, kwargs)
+        self._text = LUIText(
+            self,
+            unicode(text),
+            font,
+            font_size,
+            0,
+            0,
+            wordwrap
+        )
         self._text.z_offset = 1
         if color is None:
             self.color = LUILabel.DEFAULT_COLOR
@@ -27,10 +36,17 @@ class LUILabel(LUIObject):
             shadow = LUILabel.DEFAULT_USE_SHADOW
         self._have_shadow = shadow
         if self._have_shadow:
-            self._shadow_text = LUIText(self, unicode(text), font, font_size)
+            self._shadow_text = LUIText(
+                self,
+                unicode(text),
+                font,
+                font_size,
+                0,
+                0,
+                wordwrap
+            )
             self._shadow_text.top = 1
             self._shadow_text.color = (0,0,0,0.6)
-        LUIInitialState.init(self, kwargs)
 
     def get_text_handle(self):
         """ Returns a handle to the internal used LUIText object """

--- a/Demos/B_BlockText.py
+++ b/Demos/B_BlockText.py
@@ -1,0 +1,92 @@
+
+
+from DemoFramework import DemoFramework
+from LUILabel import LUILabel
+from LUIBlockText import LUIBlockText
+from LUIScrollableRegion import LUIScrollableRegion
+
+import random
+
+f = DemoFramework()
+f.prepare_demo("LUIBlockText")
+
+# Constructor
+
+f.add_constructor_parameter("text", "u'Label'")
+f.add_constructor_parameter("shadow", "True")
+f.add_constructor_parameter("font_size", "14")
+f.add_constructor_parameter("font", "'label'")
+
+# Functions
+f.add_public_function("clear", [])
+f.add_public_function("set_text", [("text", "string")])
+f.add_public_function("set_wrap", [("wrap", "boolean")])
+f.add_public_function("set_width", [("width", "integer")])
+
+f.add_property("labels", "list")
+
+# Events
+f.construct_sourcecode("LUIBlockText")
+
+text_container = LUIScrollableRegion(
+	parent=f.get_widget_node(),
+	width=340,
+	height=190,
+    padding=0,
+)
+
+#TODO: Support newline through charcode 10
+#TODO: If space causes next line, dont print it
+
+# Create a new label
+label = LUIBlockText(parent=text_container, width=310)
+
+# Paragraph with no line breaks
+label.add(
+	text='''Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed malesuada sit amet erat non gravida.  Pellentesque sit amet cursus risus Sed egestas, nulla in tempor cursus, ante felis cursus magna, nec vehicula nisi nulla eu nulla.''',
+	color=(0.9,0.9,.9),
+	wordwrap=True,
+	padding=5,
+)
+
+
+# Paragraph with some linebreaks
+label.add(
+	text='''Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed malesuada sit amet erat non gravida.
+Pellentesque sit amet cursus risus Sed egestas, nulla in tempor cursus, ante felis cursus magna, nec vehicula nisi nulla eu nulla.
+Nulla sed pellentesque erat.  Morbi facilisis at erat id auctor.  Phasellus euismod facilisis sem, at molestie velit condimentum sit amet.
+
+Nulla posuere rhoncus aliquam.''',
+	color=(0.9,0.9,.9),
+	wordwrap=True,
+	padding=5,
+)
+
+# Paragraph with no spaces or linebreaks
+label.add(
+	text='''Loremipsumolorsitamet,consecteturadipiscingelit.Sedmalesuadasitameteratnongravida.PellentesquesitametcursusrisusSedegestas,nullaintemporcursus,antefeliscursusmagna,necvehiculanisinullaeunulla.''',
+	color=(0.9,0.9,.9),
+	wordwrap=True,
+	padding=5,
+)
+
+def setWidth(width):
+	label.set_width(width)
+	text_container.on_element_added()
+
+def setWrap(wrap):
+	label.set_wrap(wrap)
+	text_container.on_element_added()
+
+
+f.set_actions({
+        "Set Random Text": lambda: label.set_text(unicode(random.randint(100, 10000))),
+        "Set Random Color": lambda: label.set_color((random.random(), random.random(), random.random(), 1)),
+        "Clear": lambda: label.clear(),
+        "Smaller": lambda: setWidth(200),
+        "Larger": lambda: setWidth(310),
+        "Wrapping on": lambda: setWrap(True),
+        "Wrapping off": lambda: setWrap(False),
+    })
+
+base.run()

--- a/source/luiText.cxx
+++ b/source/luiText.cxx
@@ -7,7 +7,7 @@ TypeHandle LUIText::_type_handle;
 LUIText::LUIText(PyObject* self, LUIObject* parent, const wstring& text,
                  const string& font_name, float font_size, float x, float y, bool wordwrap)
   :
-  LUIObject(self, parent, x, y),
+  LUIObject(self, parent, x, y, parent->get_parent_width(), parent->get_parent_width()),
   _text(text),
   _font_size(font_size),
   _wordwrap(wordwrap) {
@@ -51,12 +51,15 @@ void LUIText::update_text() {
   float ppu = _font_size;
   float line_height = _font->get_line_height();
 
+  vector<int> line_breaks = get_line_breaks();
+
   // Unreference all current glyphs
   _glyphs.clear();
 
   // Iterate over the sprites
   int char_idx = 0;
   float current_x_pos = 0.0f;
+  float current_y_pos = 0.0f;
 
   for (auto it = _children.begin(); it != _children.end(); ++it, ++char_idx)
   {
@@ -73,6 +76,21 @@ void LUIText::update_text() {
 #else
     const TextGlyph* const_glyph;
 #endif
+
+    // Newline
+    if (_wordwrap == TRUE && char_code == 10) {
+      current_x_pos = 0;
+      current_y_pos += floor(line_height * ppu);
+      continue;
+    }
+
+    if (_wordwrap == TRUE) {
+      if(find(line_breaks.begin(), line_breaks.end(), char_idx) != line_breaks.end()) {
+        current_x_pos = 0;
+        current_y_pos += floor(line_height * ppu);
+      }
+    }
+
     if (!_font->get_glyph(char_code, const_glyph)) {
       sprite->set_texture((Texture*)NULL);
       lui_cat.error() << "Font does not support character with char code " << char_code << ", ignoring .. target = " << _debug_name << endl;
@@ -101,7 +119,7 @@ void LUIText::update_text() {
       // Position the glyph.
       sprite->set_pos(
         current_x_pos + dynamic_glyph->get_left() * ppu,
-        (0.85 - dynamic_glyph->get_top()) * ppu + 1);
+        (0.85 - dynamic_glyph->get_top()) * ppu + 1 + current_y_pos);
 
       // The V coordinate is inverted, as panda stores the textures flipped
       sprite->set_uv_range(
@@ -118,11 +136,33 @@ void LUIText::update_text() {
       sprite->set_color(_color);
     }
 
-    // Move *cursor* by glyph length
-    current_x_pos += dynamic_glyph->get_advance() * ppu;
+    // Break word wrapping
+    if (_wordwrap == TRUE && current_x_pos + dynamic_glyph->get_advance() * ppu > get_parent_width()) {
+      // glyph length longer then width, force to next line
+      current_x_pos = 0;
+      current_y_pos += floor(line_height * ppu);
+    }
+    else {
+
+      // Trim left
+      if(_wordwrap == TRUE && current_x_pos == 0 && dynamic_glyph->get_page() == NULL) {
+        continue;
+      }
+
+      // Move *cursor* by glyph length
+      current_x_pos += dynamic_glyph->get_advance() * ppu;
+
+    }
+
+
   }
 
-  set_size( floor(current_x_pos), floor(line_height * ppu));
+  if (_wordwrap == TRUE) {
+    set_size( get_parent_width(), floor(current_y_pos + line_height * ppu));
+  }
+  else {
+    set_size( floor(current_x_pos), floor(line_height * ppu));
+  }
 }
 
 void LUIText::ls(int indent) {
@@ -190,4 +230,84 @@ float LUIText::get_char_pos(int char_index) const {
   }
 
   return cursor;
+}
+
+// Returns a list of character indexes where linebreaks should occur when wrapping.
+vector<int> LUIText::get_line_breaks() {
+
+  vector<int> result;
+
+  if(_wordwrap == TRUE) {
+
+    // Unreference all current glyphs
+    _glyphs.clear();
+
+    int char_idx = 0;
+    int word_start = 0;
+    float word_start_pos = 0.0f;
+    float future_x_pos = 0.0f;
+    float line_start = 0.0f;
+    float ppu = _font_size;
+
+    for (auto it = _children.begin(); it != _children.end(); ++it, ++char_idx)
+    {
+      LUIBaseElement* child = *it;
+      LUISprite* sprite = DCAST(LUISprite, child);
+
+      // A lui text should have only sprites contained, otherwise something went wrong
+      nassertr(sprite != NULL, result);
+
+      int char_code = (int)_text.at(char_idx);
+
+#if PANDA_MAJOR_VERSION > 1 || PANDA_MINOR_VERSION >= 10
+    CPT(TextGlyph) const_glyph;
+#else
+    const TextGlyph* const_glyph;
+#endif
+
+      // Character is a newline, so lets include this in our list.
+      if (char_code == 10) {
+        result.push_back(char_idx);
+        word_start = char_idx;
+        word_start_pos = future_x_pos;
+        line_start = future_x_pos;
+        continue;
+      }
+
+      if (!_font->get_glyph(char_code, const_glyph)) {
+        sprite->set_texture((Texture*)NULL);
+        lui_cat.error() << "Font does not support character with char code " << char_code << ", ignoring .. target = " << _debug_name << endl;
+        continue;
+      }
+
+      CPT(DynamicTextGlyph) dynamic_glyph = DCAST(DynamicTextGlyph, const_glyph);
+
+      // If this gets executed, a non-dynamic font got loaded.
+      nassertr(dynamic_glyph != NULL, result);
+
+      _glyphs.push_back(dynamic_glyph);
+
+      // If a space, lets mark this as the start of the word.
+      if (dynamic_glyph->get_page() == NULL) {
+        word_start = char_idx;
+        word_start_pos = future_x_pos + dynamic_glyph->get_advance() * ppu;
+      }
+
+      // If adding the glyph to the current position on this line will force it over
+      // the width of the label, put a new line at the start of the word.
+      if (((future_x_pos - line_start) + (dynamic_glyph->get_advance() * ppu))  > get_parent_width()) {
+        result.push_back(word_start);
+        // After the newline is added, we update the current lines start position.
+        line_start = word_start_pos;
+      }
+
+      // Move the cursor along by the glyph's width.
+      future_x_pos += dynamic_glyph->get_advance() * ppu;
+
+    }
+
+  }
+
+  return result;
+
 }

--- a/source/luiText.h
+++ b/source/luiText.h
@@ -27,7 +27,7 @@ PUBLISHED:
 
   LUIText(PyObject* self,
     LUIObject* parent, const wstring& text, const string& font_name="default",
-    float font_size=16.0f, float x=0.0f, float y=0.0f, bool wordwrap=true);
+    float font_size=16.0f, float x=0.0f, float y=0.0f, bool wordwrap=false);
   ~LUIText();
 
   INLINE void set_font(const string& font_name);
@@ -54,6 +54,7 @@ PUBLISHED:
 protected:
 
   void update_text();
+  vector<int> get_line_breaks();
 
   DynamicTextFont* _font;
   wstring _text;


### PR DESCRIPTION
I noticed wordwrap didn't seem to be implemented, and I wanted some longtext/paragraph support in my game.

The LuiText.cxx changes and moving the init function around in the LUILabel.py I'm not too sure about - but everything seems to be working ok.

I didn't use FormattedLabel because the logic around the add function is slightly different, although I could maybe put the changes into a FormattedLabel and implement a new widget if thats better.

You can add wrapping to an existing label by passing wordwrap=True and a width into the constructor.  (If you don't pass a width, it'll be 0, so will wrap on every character).  I couldn't figure out how to get the ACTUAL width of a parent element, it'd always return 0 unless it has been set explicitly.

I hope this doesn't break anything, or I'm implementing something thats already possible. 😄 