### PR TITLE
Require freetype library

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,3 @@
 generate_pdb=1
 module_name=lui
-use_lib_eigen=1
-use_lib_freetype=1
-vc_version=Visual Studio 10 2010
+require_lib_freetype=1


### PR DESCRIPTION
This fixes `<ft2build.h>` errors such as encountered in #24 when building on Linux.