### PR TITLE
fix 3/3 when panda3D double precision

### DIFF
--- a/source/luiRoot.cxx
+++ b/source/luiRoot.cxx
@@ -25,9 +25,9 @@ LUIRoot::LUIRoot(float width, float height) :
   // CPT(GeomVertexFormat) format = GeomVertexFormat::get_v3c4t2();
 
   PT(GeomVertexArrayFormat) array_format = new GeomVertexArrayFormat();
-  array_format->add_column(InternalName::make("vertex"), 3, Geom::NT_stdfloat, Geom::C_point);
+  array_format->add_column(InternalName::make("vertex"), 3, Geom::NT_float32, Geom::C_point);
   array_format->add_column(InternalName::make("color"), 4, Geom::NT_uint8, Geom::C_color);
-  array_format->add_column(InternalName::make("texcoord"), 2, Geom::NT_stdfloat, Geom::C_texcoord);
+  array_format->add_column(InternalName::make("texcoord"), 2, Geom::NT_float32, Geom::C_texcoord);
   array_format->add_column(InternalName::make("texindex"), 1, Geom::NT_uint16, Geom::C_other);
 
 


### PR DESCRIPTION
```<rdb> the problem here is that panda still defaults to 32-bit vertex data upload even in 64-bit float builds```

```<rdb> We should just use 32-bit floats for vertex data because there's no point in using 64-bit data for LUI```

```<rdb> Pixel precision is easily obtained with floats```