### PR TITLE
Fixes for building against current Panda build

### DIFF
--- a/source/config_lui.h
+++ b/source/config_lui.h
@@ -17,9 +17,6 @@ NotifyCategoryDecl(lui, EXPCL_LUI, EXPTP_LUI);
 
 extern EXPCL_LUI void init_lui();
 
-#ifdef INTERROGATE
-// Interrogate can't handle this
-#define unordered_map pmap
-#endif
+using namespace std;
 
 #endif

--- a/source/luiAtlas.cxx
+++ b/source/luiAtlas.cxx
@@ -23,7 +23,7 @@ bool LUIAtlas::load_descriptor_file(const string& descriptor_path) {
   VirtualFileSystem *vfs = VirtualFileSystem::get_global_ptr();
   PT(VirtualFile) file = vfs->get_file(descriptor_path);
 
-  if (file == (VirtualFile *)NULL) {
+  if (file == nullptr) {
     lui_cat.error() << "Could not find " << descriptor_path << endl;
     return false;
   }
@@ -64,16 +64,16 @@ bool LUIAtlas::load_texture(const string& texture_path) {
   _tex = TexturePool::load_texture(texture_path);
 
   // File not found
-  if (_tex == NULL) {
+  if (_tex == nullptr) {
     lui_cat.error() << "Failed to load atlas texture from " << texture_path << endl;
-    _tex = NULL;
+    _tex = nullptr;
     return false;
   }
 
   // Non square
   if (_tex->get_x_size() != _tex->get_y_size()) {
     lui_cat.error() << "Cannot load non-square atlas texture!" << endl;
-    _tex = NULL;
+    _tex = nullptr;
     return false;
   }
 

--- a/source/luiAtlasDescriptor.I
+++ b/source/luiAtlasDescriptor.I
@@ -4,7 +4,7 @@
  * @details This returns the texture previously stored with
  *   LUIAtlasDescriptor::set_texture(). Usually this is a handle to the atlas
  *   texture.
- * @return Texture handle, or NULL if no texture was set
+ * @return Texture handle, or nullptr if no texture was set
  */
 INLINE Texture* LUIAtlasDescriptor::get_texture() const {
   return _tex;

--- a/source/luiAtlasDescriptor.cxx
+++ b/source/luiAtlasDescriptor.cxx
@@ -7,6 +7,6 @@
  *
  */
 LUIAtlasDescriptor::LUIAtlasDescriptor() :
-  _tex(NULL)
+  _tex(nullptr)
 {
 }

--- a/source/luiAtlasPool.I
+++ b/source/luiAtlasPool.I
@@ -24,7 +24,7 @@ INLINE PT(LUIAtlas) LUIAtlasPool::get_atlas(const string& atlas_id) const {
   if (it != _atlases.end()) {
     return it->second;
   }
-  return NULL;
+  return nullptr;
 }
 
 /**

--- a/source/luiAtlasPool.cxx
+++ b/source/luiAtlasPool.cxx
@@ -1,7 +1,7 @@
 
 #include "luiAtlasPool.h"
 
-LUIAtlasPool* LUIAtlasPool::_global_ptr = NULL;
+LUIAtlasPool* LUIAtlasPool::_global_ptr = nullptr;
 
 /**
  * @brief Constructs the LUIAtlasPool
@@ -17,7 +17,7 @@ LUIAtlasPool::LUIAtlasPool() {
  * @return Handle to the global atlas pool instance
  */
 LUIAtlasPool* LUIAtlasPool::get_global_ptr() {
-  if (_global_ptr == NULL) {
+  if (_global_ptr == nullptr) {
     _global_ptr = new LUIAtlasPool();
   }
   return _global_ptr;

--- a/source/luiBaseElement.I
+++ b/source/luiBaseElement.I
@@ -956,12 +956,12 @@ INLINE bool LUIBaseElement::has_focus() const {
  * @return true if a parent is set, false otherwise
  */
 INLINE bool LUIBaseElement::has_parent() const {
-  return _parent != NULL;
+  return _parent != nullptr;
 }
 
 /**
  * @brief Returns a handle to the parent
- * @details This returns a handle to the elements parent, or NULL if no parent
+ * @details This returns a handle to the elements parent, or nullptr if no parent
  *   is present.
  * @return Handle to the parent
  */

--- a/source/luiBaseElement.cxx
+++ b/source/luiBaseElement.cxx
@@ -15,7 +15,7 @@ NotifyCategoryDef(luiBaseElement, ":lui");
 /**
  * @brief Constructs a new LUIBaseElement
  * @details This constructs a new LUIBaseElement, initializing all properties.
- *   The self pointer should be usually NULL. For python objects, interrogate
+ *   The self pointer should be usually nullptr. For python objects, interrogate
  *   automatically passes a handle to the object as the self pointer.
  *   When a self pointer is passed, all methods named on_xxx are automatically
  *   bound to events using LUIBaseElement::bind().
@@ -37,8 +37,8 @@ LUIBaseElement::LUIBaseElement(PyObject* self) :
   _clip_bounds(0.0f, 0.0f, 1e6, 1e6),
   _have_clip_bounds(false),
   _abs_clip_bounds(0.0f, 0.0f, 1e6, 1e6),
-  _parent(NULL),
-  _root(NULL),
+  _parent(nullptr),
+  _root(nullptr),
   _last_frame_visible(-1),
   _last_render_index(-1),
   _topmost(false),
@@ -66,10 +66,10 @@ void LUIBaseElement::load_python_events(PyObject* self) {
 
   // This code checks for function named "on_xxx" where xxx is an event
   // name, and auto-registers them, which is equal to bind("on_xxx", handler).
-  if (self != NULL) {
+  if (self != nullptr) {
 
     PyObject* class_methods = PyObject_Dir((PyObject*)Py_TYPE(self));
-    nassertv(class_methods != NULL);
+    nassertv(class_methods != nullptr);
     nassertv(PyList_Check(class_methods));
 
     Py_ssize_t num_elements = PyList_Size(class_methods);
@@ -82,7 +82,7 @@ void LUIBaseElement::load_python_events(PyObject* self) {
     // interrogate can't do this until after the constructor is called.
     ((Dtool_PyInstDef *)self)->_ptr_to_object = (void *)this;
     PyObject *bind_func = PyObject_GetAttrString(self, "bind");
-    nassertv(bind_func != NULL);
+    nassertv(bind_func != nullptr);
 
     // Get all attributes of the python object
     for (Py_ssize_t i = 0; i < num_elements; ++i) {
@@ -107,7 +107,7 @@ void LUIBaseElement::load_python_events(PyObject* self) {
         if (method_name_str.substr(0, event_func_prefix.size()) == event_func_prefix) {
 
           PyObject* method = PyObject_GenericGetAttr(self, method_name);
-          nassertv(method != NULL);
+          nassertv(method != nullptr);
 
           // Check if the attribute is a method
           if (PyCallable_Check(method)) {
@@ -252,7 +252,7 @@ void LUIBaseElement::blur() {
  *   it as the last render index.
  */
 void LUIBaseElement::fetch_render_index() {
-  if (_root == NULL) {
+  if (_root == nullptr) {
     _last_render_index = -1;
   } else {
     _last_render_index = _root->allocate_render_index();

--- a/source/luiBaseLayout.cxx
+++ b/source/luiBaseLayout.cxx
@@ -23,13 +23,13 @@ void LUIBaseLayout::add(PT(LUIBaseElement) object, const string& cell_mode) {
 }
 
 void LUIBaseLayout::add(PT(LUIBaseElement) object, float cell_height) {
-  Cell cell = { CM_fixed, cell_height, NULL };
+  Cell cell = { CM_fixed, cell_height, nullptr };
   add_cell(object, cell);
 }
 
 LUIObject* LUIBaseLayout::add_cell(PT(LUIBaseElement) object, Cell cell) {
   // Construct cell container object
-  LUIObject* container = new LUIObject(NULL);
+  LUIObject* container = new LUIObject(nullptr);
   add_child(container);
   if (object)
     container->add_child(object);
@@ -42,17 +42,17 @@ LUIObject* LUIBaseLayout::add_cell(PT(LUIBaseElement) object, Cell cell) {
 
 
 PT(LUIObject) LUIBaseLayout::cell(const string& cell_mode) {
-  return add_cell(NULL, construct_cell(cell_mode));
+  return add_cell(nullptr, construct_cell(cell_mode));
 }
 
 PT(LUIObject) LUIBaseLayout::cell(float cell_height) {
-  Cell cell = { CM_fixed, cell_height, NULL };
-  return add_cell(NULL, cell);
+  Cell cell = { CM_fixed, cell_height, nullptr };
+  return add_cell(nullptr, cell);
 }
 
 PT(LUIObject) LUIBaseLayout::cell() {
-  Cell cell = { CM_fit, 0.0f, NULL };
-  return add_cell(NULL, cell);
+  Cell cell = { CM_fit, 0.0f, nullptr };
+  return add_cell(nullptr, cell);
 }
 
 bool check_int(const string& str) {
@@ -71,7 +71,7 @@ int parse_int(const string& str) {
 }
 
 LUIBaseLayout::Cell LUIBaseLayout::construct_cell(const string& cell_mode) {
-  Cell cell = { CM_fit, 0.0f, NULL };
+  Cell cell = { CM_fit, 0.0f, nullptr };
 
   // Fit
   if (cell_mode == "?") {

--- a/source/luiFontPool.I
+++ b/source/luiFontPool.I
@@ -5,6 +5,6 @@ INLINE bool LUIFontPool::has_font(const string& name) const {
 }
 
 DynamicTextFont* LUIFontPool::get_font(const string& name) const {
-  nassertr(has_font(name), NULL);
+  nassertr(has_font(name), nullptr);
   return _fonts.at(name);
 }

--- a/source/luiFontPool.cxx
+++ b/source/luiFontPool.cxx
@@ -3,12 +3,12 @@
 #include "luiFontPool.h"
 
 
-LUIFontPool* LUIFontPool::_global_ptr = NULL;
+LUIFontPool* LUIFontPool::_global_ptr = nullptr;
 
 LUIFontPool::LUIFontPool() {
 
   PT(DynamicTextFont) font = DCAST(DynamicTextFont,  TextProperties::get_default_font());
-  if (font != NULL) {
+  if (font != nullptr) {
     register_font("default", font);
   } else {
     lui_cat.warning() << "Could not load default font, as it is no dynamic font!" << endl;
@@ -20,7 +20,7 @@ LUIFontPool::~LUIFontPool() {
 }
 
 LUIFontPool* LUIFontPool::get_global_ptr() {
-  if (_global_ptr == (LUIFontPool *)NULL) {
+  if (_global_ptr == nullptr) {
     _global_ptr = new LUIFontPool();
   }
   return _global_ptr;

--- a/source/luiInputHandler.cxx
+++ b/source/luiInputHandler.cxx
@@ -11,10 +11,10 @@ TypeHandle LUIInputHandler::_type_handle;
 
 LUIInputHandler::LUIInputHandler(const string& name) :
   DataNode(name),
-  _hover_element(NULL),
-  _focused_element(NULL)
+  _hover_element(nullptr),
+  _focused_element(nullptr)
 {
-  _mouse_down_elements.resize(5, NULL);
+  _mouse_down_elements.resize(5, nullptr);
   _mouse_pos_input = define_input("pixel_xy", EventStoreVec2::get_class_type());
   _buttons_input = define_input("button_events", ButtonEventList::get_class_type());
 
@@ -138,7 +138,7 @@ void LUIInputHandler::do_transmit_data(DataGraphTraverser* trav,
 }
 
 void LUIInputHandler::process(LUIRoot* root) {
-  LUIBaseElement* current_hover = NULL;
+  LUIBaseElement* current_hover = nullptr;
   int current_render_index = -1;
 
   if (_current_state.has_mouse_pos) {
@@ -168,12 +168,12 @@ void LUIInputHandler::process(LUIRoot* root) {
 
   // Check for mouse over / out events
   if (current_hover != _hover_element) {
-    if (_hover_element != NULL) {
+    if (_hover_element != nullptr) {
 
       trigger_event(_hover_element, "mouseout");
     }
 
-    if (current_hover != NULL) {
+    if (current_hover != nullptr) {
       trigger_event(current_hover, "mouseover");
     }
     _hover_element = current_hover;
@@ -182,12 +182,12 @@ void LUIInputHandler::process(LUIRoot* root) {
   // Check for mouse move
   if (_current_state.mouse_pos != _last_state.mouse_pos) {
     // Send a event to the hovered element
-    if (_hover_element != NULL) {
+    if (_hover_element != nullptr) {
       trigger_event(_hover_element, "mousemove");
     }
 
     // The focus element also recieves a mousemove element
-    if (_focused_element != NULL) {
+    if (_focused_element != nullptr) {
       trigger_event(_focused_element, "mousemove");
     }
   }
@@ -198,12 +198,12 @@ void LUIInputHandler::process(LUIRoot* root) {
   for (size_t mouse_button = 0; mouse_button < 5; ++mouse_button) {
 
     if (mouse_key_pressed(mouse_button)) {
-      if (_hover_element != NULL && _hover_element->is_visible()) {
+      if (_hover_element != nullptr && _hover_element->is_visible()) {
         _mouse_down_elements[mouse_button] = _hover_element;
 
         trigger_event(_hover_element, "mousedown", get_mouse_button_name(mouse_button));
 
-        if (_focused_element != NULL && _hover_element != _focused_element) {
+        if (_focused_element != nullptr && _hover_element != _focused_element) {
           // When clicking somewhere, and the clicked element is not the focused one,
           // make the focused one loose focus
           lost_focus = true;
@@ -212,11 +212,11 @@ void LUIInputHandler::process(LUIRoot* root) {
     }
 
     if (mouse_key_released(mouse_button)) {
-      if (_mouse_down_elements[mouse_button] != NULL) {
+      if (_mouse_down_elements[mouse_button] != nullptr) {
         trigger_event(_mouse_down_elements[mouse_button], "mouseup", get_mouse_button_name(mouse_button));
       }
 
-      if (_mouse_down_elements[mouse_button] != NULL && _mouse_down_elements[mouse_button] == _hover_element) {
+      if (_mouse_down_elements[mouse_button] != nullptr && _mouse_down_elements[mouse_button] == _hover_element) {
         trigger_event(_mouse_down_elements[mouse_button], "click", get_mouse_button_name(mouse_button));
       }
     }
@@ -226,26 +226,26 @@ void LUIInputHandler::process(LUIRoot* root) {
   LUIBaseElement* requested_focus = root->get_requested_focus();
 
 
-  if (requested_focus == NULL) {
+  if (requested_focus == nullptr) {
     // No focus request, eveything remains the same
     // However, when the user clicked somewhere, and it was not the focused element,
     // make it loose the focus. It is important this happens after calling the
     // click event, otherwise we might loose events.
 
-    if (_focused_element != NULL && (lost_focus || root->get_explicit_blur())) {
+    if (_focused_element != nullptr && (lost_focus || root->get_explicit_blur())) {
       _focused_element->set_focus(false);
       trigger_event(_focused_element, "blur");
-      _focused_element = NULL;
+      _focused_element = nullptr;
     }
   } else {
     // Focus was requested, and its different from the current focused element
     if (requested_focus != _focused_element) {
 
       // Tell the currently focused element its no longer focused
-      if (_focused_element != NULL) {
+      if (_focused_element != nullptr) {
         _focused_element->set_focus(false);
         trigger_event(_focused_element, "blur");
-        _focused_element = NULL;
+        _focused_element = nullptr;
       }
 
       // Tell the new element its now focused
@@ -259,13 +259,13 @@ void LUIInputHandler::process(LUIRoot* root) {
 
   // Reset any requested focus, since the element should be in focus now 
   if (root->get_requested_focus()) {
-    root->set_requested_focus(NULL);
+    root->set_requested_focus(nullptr);
   }
   
   root->clear_explicit_blur();
 
   // Check key events
-  if (_focused_element != NULL && _focused_element->is_visible()) {
+  if (_focused_element != nullptr && _focused_element->is_visible()) {
     vector<LUIKeyEvent>::const_iterator it;
     for (it = _key_events.begin(); it != _key_events.end(); ++it) {
 

--- a/source/luiIterators.h
+++ b/source/luiIterators.h
@@ -20,7 +20,7 @@ PUBLISHED:
     if (_iter != _end) {
       return *_iter++;
     }
-    return NULL;
+    return nullptr;
   }
   INLINE LUIElementIterator& __iter__() {
     return *this;

--- a/source/luiObject.I
+++ b/source/luiObject.I
@@ -22,7 +22,7 @@ INLINE void LUIObject::remove_child(PT(LUIBaseElement) child) {
 
   _children.erase(child_it);
   child->on_detached();
-  child->do_set_parent(NULL);
+  child->do_set_parent(nullptr);
 
   if (luiObject_cat.is_spam()) {
     luiObject_cat.spam() << "Reference count is now: " << child->get_ref_count() << endl;
@@ -43,7 +43,7 @@ INLINE void LUIObject::remove_all_children() {
   // Detach all children
   for (auto it = _children.begin(); it != _children.end(); ++it) {
     (*it)->on_detached();
-    (*it)->do_set_parent(NULL);
+    (*it)->do_set_parent(nullptr);
   }
 
   // Now clear the vector
@@ -77,7 +77,7 @@ INLINE PT(LUIElementIterator) LUIObject::get_children() const {
 }
 
 INLINE PT(LUIBaseElement) LUIObject::get_child(size_t index) const {
-  nassertr(index < _children.size(), NULL);
+  nassertr(index < _children.size(), nullptr);
   return _children[index];
 }
 
@@ -91,8 +91,8 @@ INLINE void LUIObject::on_detached() {
   }
 
   unregister_events();
-  _root = NULL;
-  _parent = NULL;
+  _root = nullptr;
+  _parent = nullptr;
 
   for (auto it = _children.begin(); it!= _children.end(); ++it) {
     (*it)->on_detached();

--- a/source/luiObject.cxx
+++ b/source/luiObject.cxx
@@ -34,14 +34,14 @@ LUIObject::~LUIObject() {
 
 void LUIObject::init() {
   ++_instance_count;
-  _content_node = NULL;
+  _content_node = nullptr;
   if (luiObject_cat.is_spam()) {
     luiObject_cat.spam() << "Constructing new LUIObject (active: " << _instance_count << ")" << endl;
   }
 }
 
 void LUIObject::set_root(LUIRoot* root) {
-  if (_root != NULL && root != _root) {
+  if (_root != nullptr && root != _root) {
     luiObject_cat.error() << "Object is already attached to another root! target = " << _debug_name << endl;
     return;
   }
@@ -86,7 +86,7 @@ void LUIObject::render_recursive(bool is_topmost_pass, bool render_anyway) {
     do_render_anyway = do_render_anyway || do_render;
   }
 
-  nassertv(_root != NULL);
+  nassertv(_root != nullptr);
 
   if (do_render) {
     _last_frame_visible = _root->get_frame_index();

--- a/source/luiRegion.cxx
+++ b/source/luiRegion.cxx
@@ -13,7 +13,7 @@ LUIRegion::
   LUIRegion(GraphicsOutput* window, const LVecBase4& dr_dimensions,
   const string& context_name) :
   DisplayRegion(window, dr_dimensions),
-  _input_handler(NULL),
+  _input_handler(nullptr),
   _wireframe(false) {
 
   if (lui_cat.is_spam()) {
@@ -58,7 +58,7 @@ void LUIRegion::
       _lens->set_film_offset(_width * 0.5, _height * 0.5);
     }
 
-    if (_input_handler != NULL) {
+    if (_input_handler != nullptr) {
       _input_handler->process(_lui_root);
     }
 
@@ -66,7 +66,7 @@ void LUIRegion::
 
     trav->set_cull_handler(cull_handler);
     trav->set_scene(scene_setup, gsg, get_incomplete_render());
-    trav->set_view_frustum(NULL);
+    trav->set_view_frustum(nullptr);
 
     CPT(RenderAttrib) shaderAttrib = ShaderAttrib::make_default();
 

--- a/source/luiRoot.I
+++ b/source/luiRoot.I
@@ -19,7 +19,7 @@ INLINE int LUIRoot::alloc_index_by_texture(Texture* tex) {
     lui_cat.spam() << "Finding vertex pool for texture " << tex << endl;
   }
 
-  nassertr(tex != NULL, -1);
+  nassertr(tex != nullptr, -1);
 
   auto index = std::find(_textures.begin(), _textures.end(), tex);
 
@@ -81,7 +81,7 @@ INLINE int LUIRoot::register_sprite(LUISprite* sprite) {
 
   // Check if there is space free
   for(int i = 0; i != _sprites.size(); i++) {
-      if (_sprites[i] == NULL) {
+      if (_sprites[i] == nullptr) {
         _sprites[i] = sprite;
         return i;
       }
@@ -101,7 +101,7 @@ INLINE void LUIRoot::unregister_sprite(int position) {
   // A sprite shouldn't have an invalid index
   nassertv(position < _sprites.size() && position >= 0);
 
-  _sprites[position] = NULL;
+  _sprites[position] = nullptr;
 
   // TODO: If this sprite is the last size, make the vector smaller
   // (Strip empty elements from the end)
@@ -112,8 +112,8 @@ INLINE void* LUIRoot::get_sprite_vertex_pointer(int position) const {
   nassertr(position < _sprites.size() && position >= 0, 0);
 
   // At the position there should be an actual sprite
-  nassertr(_sprites[position] != NULL, 0);
-  nassertr(_sprite_vertex_pointer != NULL, 0);
+  nassertr(_sprites[position] != nullptr, 0);
+  nassertr(_sprite_vertex_pointer != nullptr, 0);
 
   // nassertr(_sprite_vertex_pointer == _vertex_data->modify_array(0)->modify_handle()->get_write_pointer(), 0);
 
@@ -152,7 +152,7 @@ INLINE int LUIRoot::get_num_textures() const {
 }
 
 INLINE Texture* LUIRoot::get_texture(int index) const {
-  nassertr(index >= 0 && index < _textures.size(), NULL);
+  nassertr(index >= 0 && index < _textures.size(), nullptr);
   return _textures[index];
 }
 
@@ -183,7 +183,7 @@ INLINE void LUIRoot::set_use_glsl_130(bool use_glsl_130) {
  *   in some cases it might make sense to blur an element.
  */
 INLINE void LUIRoot::request_explicit_blur() {
-  request_focus(NULL);
+  request_focus(nullptr);
   _explicit_blur = true;
 }
 

--- a/source/luiRoot.cxx
+++ b/source/luiRoot.cxx
@@ -7,18 +7,18 @@ bool LUIRoot::_use_glsl_130 = false;
 
 
 LUIRoot::LUIRoot(float width, float height) : 
-  _requested_focus(NULL),
+  _requested_focus(nullptr),
   _explicit_blur(false),
   _sprites_rendered(0),
   _frame_count(0),
   _render_index(0),
-  _sprite_vertex_pointer(NULL),
+  _sprite_vertex_pointer(nullptr),
   _index_buffer_size(1000000) {
 
   if (lui_cat.is_spam()) {
     lui_cat.spam() << "Constructing new LUIRoot ..\n";
   }
-  _root = new LUIObject(NULL, 0.0f, 0.0f, width, height);
+  _root = new LUIObject(nullptr, 0.0f, 0.0f, width, height);
   _root->set_root(this);
 
   // Create vertex chunks
@@ -93,7 +93,7 @@ void LUIRoot::prepare_render() {
     memcpy(_triangles->modify_vertices()->modify_handle()->get_write_pointer(), _triangle_index_buffer, _sprites_rendered * sizeof(LUITriangleIndex) * 2);
 
     nassertv(_min_rendered_vertex < _max_rendered_vertex);
-    _triangles->set_minmax(_min_rendered_vertex, _max_rendered_vertex, NULL, NULL);
+    _triangles->set_minmax(_min_rendered_vertex, _max_rendered_vertex, nullptr, nullptr);
   }
 
   if (lui_cat.is_spam()) {

--- a/source/luiSprite.I
+++ b/source/luiSprite.I
@@ -26,14 +26,14 @@ INLINE void LUISprite::set_texture(Texture* tex, bool resize) {
   _texture_index = -1;
 
   // Unassign old texture
-  if (_tex != NULL) {
+  if (_tex != nullptr) {
     _tex = tex;
     _debug_source = tex->get_name();
   } else {
-    _debug_source = "NULL";
+    _debug_source = "nullptr";
   }
 
-  if (tex != NULL) {
+  if (tex != nullptr) {
     if (luiSprite_cat.is_spam()) {
       luiSprite_cat.spam() << "Assigned texture of size " << tex->get_x_size() << "x" << tex->get_y_size() << endl;
     }
@@ -46,7 +46,7 @@ INLINE void LUISprite::set_texture(Texture* tex, bool resize) {
     }
 
     // Assign new index
-    if (_root != NULL) {
+    if (_root != nullptr) {
         fetch_texture_index();
     }
   }
@@ -83,7 +83,7 @@ INLINE void LUISprite::set_texture(const string& source, bool resize) {
     // load texture from file
     PT(Texture) tex = TexturePool::load_texture(source);
 
-    if (tex == NULL) {
+    if (tex == nullptr) {
       luiSprite_cat.error() << "Could not load texture from '" << source << "'" << endl;
       return;
     }
@@ -116,11 +116,11 @@ INLINE void LUISprite::print_vertices() {
 
 INLINE void LUISprite::on_detached() {
   unregister_events();
-  if (_tex != NULL) {
+  if (_tex != nullptr) {
     unassign_sprite_index();
   }
-  _root = NULL;
-  _parent = NULL;
+  _root = nullptr;
+  _parent = nullptr;
 }
 
 INLINE void LUISprite::init_size(float w, float h) {

--- a/source/luiSprite.cxx
+++ b/source/luiSprite.cxx
@@ -12,9 +12,9 @@ TypeHandle LUISprite::_type_handle;
 NotifyCategoryDef(luiSprite, ":lui");
 
 LUISprite::LUISprite(LUIText* parent_text)
-  : LUIBaseElement(NULL) {
+  : LUIBaseElement(nullptr) {
   init((LUIObject*)parent_text, 0, 0, LColor(1));
-  set_texture(NULL, true);
+  set_texture(nullptr, true);
 }
 
 
@@ -48,7 +48,7 @@ LUISprite::LUISprite(PyObject* self, LUIObject* parent, const string& entry_id,
 void LUISprite::init(LUIObject* parent, float x, float y, const LColor& color) {
 
   // A lui sprite always needs a parent
-  nassertv(parent != NULL);
+  nassertv(parent != nullptr);
 
 
   _last_frame_visible = -1;
@@ -92,7 +92,7 @@ void LUISprite::set_root(LUIRoot* root) {
     luiSprite_cat.spam() << "Root changed to " << root << " .." << endl;
   }
 
-  if (_root != NULL && _root != root) {
+  if (_root != nullptr && _root != root) {
     luiSprite_cat.warning() << "Unregistering from old LUIRoot .. you should detach the sprite from the old root first .." << endl;
     unassign_sprite_index();
   }
@@ -115,7 +115,7 @@ void LUISprite::assign_sprite_index() {
   // This should never happen, as all methods which call this method
   // should check if the root is already set. Otherwise something
   // went really wrong.
-  nassertv(_root != NULL);
+  nassertv(_root != nullptr);
 
   _sprite_index = _root->register_sprite(this);
 
@@ -128,7 +128,7 @@ void LUISprite::assign_sprite_index() {
 }
 
 void LUISprite::update_vertex_pool() {
-  if (_sprite_index >= 0 && _root != NULL) {
+  if (_sprite_index >= 0 && _root != nullptr) {
 
     if (luiSprite_cat.is_spam()) {
       luiSprite_cat.spam() << "Updating vertex pool slot " << _sprite_index << endl;
@@ -137,7 +137,7 @@ void LUISprite::update_vertex_pool() {
     void* write_pointer = _root->get_sprite_vertex_pointer(_sprite_index);
 
     // This should never happen
-    nassertv(write_pointer != NULL);
+    nassertv(write_pointer != nullptr);
 
     if (luiSprite_cat.is_spam()) {
       luiSprite_cat.spam() << "Memcopying to " << write_pointer << endl;
@@ -153,7 +153,7 @@ void LUISprite::unassign_sprite_index() {
     luiSprite_cat.spam() << "Unassign vertex pool" << endl;
   }
 
-  if (_sprite_index >= 0 && _root != NULL) {
+  if (_sprite_index >= 0 && _root != nullptr) {
     _root->unregister_sprite(_sprite_index);
     _sprite_index = -1;
   }
@@ -244,7 +244,7 @@ void LUISprite::recompute_vertices() {
 }
 
 void LUISprite::fetch_texture_index() {
-  if (_tex != NULL) {
+  if (_tex != nullptr) {
     _texture_index = _root->alloc_index_by_texture(_tex);
   }
 }
@@ -259,7 +259,7 @@ void LUISprite::render_recursive(bool is_topmost_pass, bool render_anyway) {
   _last_render_index = -1;
 
   // We should have a root
-  nassertv(_root != NULL);
+  nassertv(_root != nullptr);
   // We also should have a index
   nassertv(_sprite_index >= 0);
 

--- a/source/luiText.cxx
+++ b/source/luiText.cxx
@@ -21,7 +21,7 @@ LUIText::~LUIText() {
 void LUIText::update_text() {
   int len = _text.size();
 
-  nassertv(_font != NULL);
+  nassertv(_font != nullptr);
 
   if (lui_cat.is_spam()) {
     lui_cat.spam() << "Current text is '" << _text.c_str() << "'" << endl;
@@ -67,7 +67,7 @@ void LUIText::update_text() {
     LUISprite* sprite = DCAST(LUISprite, child);
 
     // A lui text should have only sprites contained, otherwise something went wrong
-    nassertv(sprite != NULL);
+    nassertv(sprite != nullptr);
 
     int char_code = (int)_text.at(char_idx);
 
@@ -92,7 +92,7 @@ void LUIText::update_text() {
     }
 
     if (!_font->get_glyph(char_code, const_glyph)) {
-      sprite->set_texture((Texture*)NULL);
+      sprite->set_texture(nullptr);
       lui_cat.error() << "Font does not support character with char code " << char_code << ", ignoring .. target = " << _debug_name << endl;
       continue;
     }
@@ -100,12 +100,12 @@ void LUIText::update_text() {
     CPT(DynamicTextGlyph) dynamic_glyph = DCAST(DynamicTextGlyph, const_glyph);
 
     // If this gets executed, a non-dynamic font got loaded.
-    nassertv(dynamic_glyph != NULL);
+    nassertv(dynamic_glyph != nullptr);
 
     _glyphs.push_back(dynamic_glyph);
 
     // Some characters have no texture (like space)
-    if (dynamic_glyph->get_page() == NULL) {
+    if (dynamic_glyph->get_page() == nullptr) {
       lui_cat.debug() << "Character '" << (char)char_code << "' (Code: " << char_code << ") has no texture page!" << endl;
       sprite->hide();
 
@@ -145,7 +145,7 @@ void LUIText::update_text() {
     else {
 
       // Trim left
-      if (_wordwrap && current_x_pos == 0 && dynamic_glyph->get_page() == NULL) {
+      if (_wordwrap && current_x_pos == 0 && dynamic_glyph->get_page() == nullptr) {
         continue;
       }
 
@@ -175,7 +175,7 @@ int LUIText::get_char_index(float pos) const {
   if (lui_cat.is_spam()) {
     lui_cat.spam() << "Trying to resolve " << pos << " into a character index .." << endl;
   }
-  nassertr(_font != NULL, 0);
+  nassertr(_font != nullptr, 0);
 
   float cursor = 0.0f;
 
@@ -192,7 +192,7 @@ int LUIText::get_char_index(float pos) const {
       continue;
     }
 
-    nassertr(glyph != NULL, 0);
+    nassertr(glyph != nullptr, 0);
     cursor += glyph->get_advance() * _font_size;
 
     if (cursor > pos) {
@@ -206,7 +206,7 @@ float LUIText::get_char_pos(int char_index) const {
   if (lui_cat.is_spam()) {
     lui_cat.spam() << "Trying to resolve " << char_index << " into a character position .." << endl;
   }
-  nassertr(_font != NULL, 0);
+  nassertr(_font != nullptr, 0);
 
   // Make sure we don't iterate over the text bounds
   int iterate_max = min(char_index, (int)_text.size());
@@ -225,7 +225,7 @@ float LUIText::get_char_pos(int char_index) const {
       lui_cat.error() << "Font does not support character with char code " << char_code << ", ignoring .. target = " << _debug_name << endl;
       continue;
     }
-    nassertr(glyph != NULL, 0);
+    nassertr(glyph != nullptr, 0);
     cursor += glyph->get_advance() * _font_size;
   }
 
@@ -255,7 +255,7 @@ vector<int> LUIText::get_line_breaks() {
       LUISprite* sprite = DCAST(LUISprite, child);
 
       // A lui text should have only sprites contained, otherwise something went wrong
-      nassertr(sprite != NULL, result);
+      nassertr(sprite != nullptr, result);
 
       int char_code = (int)_text.at(char_idx);
 
@@ -275,7 +275,7 @@ vector<int> LUIText::get_line_breaks() {
       }
 
       if (!_font->get_glyph(char_code, const_glyph)) {
-        sprite->set_texture((Texture*)NULL);
+        sprite->set_texture(nullptr);
         lui_cat.error() << "Font does not support character with char code " << char_code << ", ignoring .. target = " << _debug_name << endl;
         continue;
       }
@@ -283,12 +283,12 @@ vector<int> LUIText::get_line_breaks() {
       CPT(DynamicTextGlyph) dynamic_glyph = DCAST(DynamicTextGlyph, const_glyph);
 
       // If this gets executed, a non-dynamic font got loaded.
-      nassertr(dynamic_glyph != NULL, result);
+      nassertr(dynamic_glyph != nullptr, result);
 
       _glyphs.push_back(dynamic_glyph);
 
       // If a space, lets mark this as the start of the word.
-      if (dynamic_glyph->get_page() == NULL) {
+      if (dynamic_glyph->get_page() == nullptr) {
         word_start = char_idx;
         word_start_pos = future_x_pos + dynamic_glyph->get_advance() * ppu;
       }

--- a/source/luiVertexChunk.I
+++ b/source/luiVertexChunk.I
@@ -20,7 +20,7 @@ INLINE int LUIVertexChunk::reserve_slot(LUISprite* sprite) {
 
   int slot = -1;
   for (int i = 0; i < _chunk_size; i++) {
-    if (_children[i] == NULL) {
+    if (_children[i] == nullptr) {
       // found slot
       slot = i;
       break;
@@ -41,12 +41,12 @@ INLINE void LUIVertexChunk::free_slot(int slot) {
   nassertv(slot < _chunk_size);
   nassertv(!is_empty());
 
-  if (_children[slot] == NULL) {
+  if (_children[slot] == nullptr) {
     lui_cat.error() << "Cannot free slot, as it is not used" << endl;
     return;
   }
 
-  _children[slot] = NULL;
+  _children[slot] = nullptr;
   _sprite_count --;
 
 
@@ -70,10 +70,10 @@ INLINE void LUIVertexChunk::free_slot(int slot) {
 INLINE void* LUIVertexChunk::get_slot_ptr(int slot) const {
 
   // Make sure the write pointer is correct
-  nassertr(_vertex_data->modify_array(0)->modify_handle()->get_write_pointer() == _write_pointer, NULL);
+  nassertr(_vertex_data->modify_array(0)->modify_handle()->get_write_pointer() == _write_pointer, nullptr);
 
   // Make sure we don't write at the wrong location
-  nassertr(slot < _chunk_size, NULL);
+  nassertr(slot < _chunk_size, nullptr);
 
   return (void*)((uintptr_t)_write_pointer + sizeof(LUIVertexData) * 4 * slot);
 }

--- a/source/luiVertexChunk.cxx
+++ b/source/luiVertexChunk.cxx
@@ -45,7 +45,7 @@ LUIVertexChunk::LUIVertexChunk(int chunk_size)
   _children = new LUISprite*[chunk_size];
 
   for (int i = 0; i < chunk_size; i++) {
-    _children[i] = NULL;
+    _children[i] = nullptr;
   }
 
 }

--- a/source/luiVertexPool.I
+++ b/source/luiVertexPool.I
@@ -5,6 +5,6 @@ INLINE int LUIVertexPool::get_num_chunks() const {
 
 }
 INLINE LUIVertexChunk* LUIVertexPool::get_chunk(int n) const {
-  nassertr(n >= 0 && n < _chunks.size(), NULL);
+  nassertr(n >= 0 && n < _chunks.size(), nullptr);
   return _chunks[n];
 }

--- a/source/luiVertexPool.cxx
+++ b/source/luiVertexPool.cxx
@@ -25,7 +25,7 @@ LUIVertexPool::~LUIVertexPool() {
 
 LUIChunkDescriptor* LUIVertexPool::allocate_slot(LUISprite* child) {
 
-  LUIVertexChunk* chunk = NULL;
+  LUIVertexChunk* chunk = nullptr;
 
   for (int i = 0; i < _chunks.size(); i++) {
     LUIVertexChunk* current = _chunks[i];
@@ -35,7 +35,7 @@ LUIChunkDescriptor* LUIVertexPool::allocate_slot(LUISprite* child) {
     }
   }
 
-  if (chunk == NULL) {
+  if (chunk == nullptr) {
     if (lui_cat.is_spam()) {
       lui_cat.spam() << "Allocating new lui vertex chunk .." << endl;
     }
@@ -47,12 +47,12 @@ LUIChunkDescriptor* LUIVertexPool::allocate_slot(LUISprite* child) {
     }
   }
 
-  // At this place, the chunk should not be NULL. Either we allocated a new one,
+  // At this place, the chunk should not be nullptr. Either we allocated a new one,
   // or we took an existing one, but in all cases we have one.
-  nassertr(chunk != NULL, NULL);
+  nassertr(chunk != nullptr, nullptr);
 
   int slot = chunk->reserve_slot(child);
-  nassertr(slot >= 0, NULL);
+  nassertr(slot >= 0, nullptr);
 
   LUIChunkDescriptor* result = new LUIChunkDescriptor();
   result->set_chunk(chunk);


### PR DESCRIPTION
Building against a recent Panda was broken for several reasons:

1. We do have an `unordered_map` header in Panda, so the #define was causing that to no longer parse correctly.
2. Panda3D no longer has `using namespace std;` (see panda3d/panda3d#335) so this adds that into `config_lui.h` for now.  It would be even better to use `using std::string;` etc. for each individual thing that is used from `std` without prefix, or even to fix the headers to just use the `std` prefix.
3. Panda3D has `nullptr_t` overloads of PointerTo, so using `NULL` for PointerTo in a few places caused ambiguity.  I've just replaced all instances of `NULL` with `nullptr`.

Fixes #47